### PR TITLE
Convert merged solution fields to .vti file for visualization in Paraview

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "six",
     "swirl-dynamics@git+https://github.com/google-research/swirl-dynamics",
     "tensorflow",
+    "vtk",
 ]
 
 # This is set automatically by flit using `swirl_lm.__version__`


### PR DESCRIPTION
Take one (or multiple) merged 3D solution fields from swirl-lm and convert to a single .vti file for visualization in [Paraview](https://www.paraview.org/). Assumes structured data with a constant grid resolution.
For example, solution fields (e.g., rho, u, v, w, p can be merged with `load_and_merge_serialized_tensor`, before being passed to `write_vtk_file`.
(New PR with signed CLA this time)