### PR TITLE
[IB method] Implemented new ghost point method

### DIFF
--- a/swirl_lm/boundary_condition/immersed_boundary_method.proto
+++ b/swirl_lm/boundary_condition/immersed_boundary_method.proto
@@ -124,8 +124,19 @@ message FeedbackForce1DInterp {
   optional float damping_coeff = 3 [default = 1.0];
 }
 
+message GhostPointMethod {
+  // Variables for which the ghost point method is applied.
+  repeated IBVariableInfo variables = 1;
+  // The surface function of the immersed boundary. Only analytical functions
+  // are currently supported. Should be one of `sine`, `ramp`,
+  // `witch_of_agnesi`, or `witch_of_agnesi_2d`. 
+  // optional string profile = 2;
+  // The value of the damping coefficient.
+  optional float damping_coeff = 2 [default = 10.0];
+}
+
 // Parameters required by the immersed boundary method.
-// Next id: 7
+// Next id: 8
 message ImmersedBoundaryMethod {
   oneof type {
     CartesianGridMethod cartesian_grid = 1;
@@ -134,5 +145,6 @@ message ImmersedBoundaryMethod {
     DirectForcingMethod direct_forcing = 4;
     DirectForcing1DInterp direct_forcing_1d_interp = 6;
     FeedbackForce1DInterp feedback_force_1d_interp = 5;
+    GhostPointMethod ghost_point_method = 7;
   }
 }

--- a/swirl_lm/equations/scalars.py
+++ b/swirl_lm/equations/scalars.py
@@ -261,7 +261,10 @@ class Scalars(object):
         rho_sc_name = 'rho_{}'.format(scalar_name)
         rhs_name = self._ib.ib_rhs_name(rho_sc_name)
         helper_states = {rhs_name: rhs}
-        for helper_var_name in ('ib_interior_mask', 'ib_boundary'):
+        for helper_var_name in ('ib_interior_mask', 'ib_boundary',
+              'ib_delta_weights', 'ib_norm_dist', 'ijk_gp', 'gp_mask',
+              'ib_interp_weights', 'idx_p', 'idx_q', 'idx_s', 'dist',
+              'summed_weights'):
           if helper_var_name in additional_states:
             helper_states[helper_var_name] = additional_states[
                 helper_var_name

--- a/swirl_lm/equations/velocity.py
+++ b/swirl_lm/equations/velocity.py
@@ -391,7 +391,10 @@ class Velocity(object):
           var_name = _KEYS_MOMENTUM[dim]
           rhs_name = self._ib.ib_rhs_name(var_name)
           helper_states = {rhs_name: rhs}
-          for helper_var_name in ('ib_interior_mask', 'ib_boundary'):
+          for helper_var_name in ('ib_interior_mask', 'ib_boundary',
+              'ib_delta_weights', 'ib_norm_dist', 'ijk_gp', 'gp_mask',
+              'ib_interp_weights', 'idx_p', 'idx_q', 'idx_s', 'dist',
+              'summed_weights'):
             if helper_var_name in additional_states:
               helper_states[helper_var_name] = additional_states[
                   helper_var_name

--- a/swirl_lm/example/fire/run_witch_of_agnesi.sh
+++ b/swirl_lm/example/fire/run_witch_of_agnesi.sh
@@ -1,0 +1,34 @@
+TPU="node-1"
+GCS_DIR="gs://swirllm_bucket/witch_of_agnesi/non_reacting_flow"
+SURFACE_TYPE=WITCHOFAGNESI2D # or: FILE | RAMP | BUMP
+TERRAIN_FILE=None # swirl-lm/swirl_lm/example/fire/tubbs_1k_20kmx20km.ser
+
+python3 ./fire_main.py \
+  --simulation_debug=true \
+  --c_d=0.01 --dt=0.01 \
+  --flat_surface_ignite=False --flat_surface_include_fire=False \
+  --flat_surface_init_bl=True \
+  --flat_surface_blasius_bl_distance=100000000.0 \
+  --flat_surface_blasius_bl_transition=False --flat_surface_blasius_bl_fraction=0.5 \
+  --flat_surface_terrain_type=${SURFACE_TYPE} --flat_surface_turbulent_inflow=False \
+  --flat_surface_include_coriolis_force=True \
+  --flat_surface_use_dynamic_igniter=False \
+  --fuel_bed_height=0.0 --fuel_density=0.0 \
+  --kernel_size=16 \
+  --loading_step=0 \
+  --lx=6000.0 --ly=6000.0 --lz=4500.0 \
+  --moisture_density=0.0 \
+  --num_boundary_points=0 \
+  --nx=64 --ny=64 --nz=64 \
+  --cx=2 --cy=2 --cz=2 \
+  --opt_filter_fuel_density=False \
+  --start_step=0 \
+  --terrain_filepath=${TERRAIN_FILE} \
+  --use_geopotential=False \
+  --t_init=283.0 \
+  --y_o_init=0.21 \
+  --velocity_init_inflow_opt=FROM_COMPONENT_FLAGS \
+  --u_init=10.0 --v_init=0.0 \
+  --data_dump_prefix=${GCS_DIR} \
+  --config_filepath=./witch_of_agnesi.pbtxt \
+  --target=$TPU

--- a/swirl_lm/example/fire/witch_of_agnesi.pbtxt
+++ b/swirl_lm/example/fire/witch_of_agnesi.pbtxt
@@ -1,0 +1,218 @@
+# proto-file: third_party/py/swirl_lm/base/parameters.proto
+# proto-message: SwirlLMParameters
+solver_procedure: VARIABLE_DENSITY
+convection_scheme: CONVECTION_SCHEME_QUICK
+diffusion_scheme: DIFFUSION_SCHEME_CENTRAL_3
+time_integration_scheme: TIME_SCHEME_CN_EXPLICIT_ITERATION
+enable_rhie_chow_correction: true
+num_sub_iterations: 3
+use_3d_tf_tensor: true
+simulation_time_info {
+  from_config {
+    num_cycles: 1
+    num_steps: 100
+  }
+}
+pre_post_process_info {
+  from_config {
+    apply_preprocess: true
+    preprocess_periodic: false
+    apply_postprocess: false
+    postprocess_periodic: false
+    preprocess_step_id: 0
+    postprocess_step_id: 1
+  }
+}
+use_sgs: false
+sgs_model {
+  smagorinsky {
+    c_s: 0.18
+    pr_t: 1.0
+  }
+}
+periodic {
+  dim_0: true dim_1: true dim_2: false
+}
+gravity_direction {
+  dim_0: 0.0 dim_1: 0.0 dim_2: -1.0
+}
+pressure {
+  solver {
+    jacobi {
+      max_iterations: 100 halo_width: 2 omega: 0.67
+    }
+  }
+  num_d_rho_filter: 3
+  pressure_outlet: true
+}
+thermodynamics {
+  constant_density {}
+  # ideal_gas_law {
+  #   const_theta: 283.0
+  # }
+}
+density: 1.0
+p_thermal: 1.01325e5
+kinematic_viscosity: 20.0
+scalars {
+  name: "T"
+  diffusivity: 1.0e-2
+  reference_value: 283.0
+}
+scalars {
+  name: "Y_O"
+  diffusivity: 1.0e-2
+  density: 1.0
+  molecular_weight: 0.029
+}
+scalars {
+  name: "ambient"
+  diffusivity: 1.0e-2
+  density: 1.0
+  molecular_weight: 0.029
+  solve_scalar: false
+}
+boundary_models {
+  ib {
+    ghost_point_method {
+      #damping_coeff: 10.0
+      variables { name: "rho_u" value: 0.0 bc: DIRICHLET override: false }
+      variables { name: "rho_v" value: 0.0 bc: DIRICHLET override: false }
+      variables { name: "rho_w" value: 0.0 bc: DIRICHLET override: false }
+      variables { name: "rho_T" value: 283.0 bc: DIRICHLET override: false }
+      variables { name: "rho_Y_O" value: 0.21 bc: DIRICHLET override: false }
+    }
+  }
+  # sponge {
+  #   orientation {dim: 0 face: 1 fraction: 0.05 }
+  #   orientation {dim: 2 face: 1 fraction: 0.05 }
+  #   variable_info {
+  #     name: "u" target_state_name: "u_log" override: true
+  #   }
+  #   variable_info {
+  #     name: "v" target_value: 0.0 override: true
+  #   }
+  #   variable_info {
+  #     name: "w" target_value: 0.0 override: true
+  #   }
+  #   variable_info {
+  #     name: "theta" target_value: 283.0 override: false
+  #   }
+  #   variable_info {
+  #     name: "Y_O" target_value: 0.21 override: false
+  #   }
+  # }
+}
+# additional_state_keys: "sponge_beta"
+# additional_state_keys: "u_log"
+# additional_state_keys: "zz"
+additional_state_keys: "ib_interior_mask"
+additional_state_keys: "ib_boundary"
+# additional_state_keys: "bc_u_0_0"
+
+additional_state_keys: "gp_mask"
+additional_state_keys: "ib_norm_dist"
+helper_var_keys: "ib_interp_weights"
+helper_var_keys: "summed_weights"
+helper_var_keys: "idx_p"
+helper_var_keys: "idx_q"
+helper_var_keys: "idx_s"
+helper_var_keys: "dist"
+helper_var_keys: "ijk_gp"
+helper_var_keys: "x_ip"
+helper_var_keys: "y_ip"
+helper_var_keys: "z_ip"
+helper_var_keys: "x_gp"
+helper_var_keys: "y_gp"
+helper_var_keys: "z_gp"
+
+boundary_conditions {
+  name: "u"
+  boundary_info {
+    dim: 0 location: 0 type: BC_TYPE_DIRICHLET value: 10.0
+  }
+  boundary_info {
+    dim: 0 location: 1 type: BC_TYPE_NEUMANN value: 0.0
+  }
+  boundary_info {
+    dim: 2 location: 0 type: BC_TYPE_NEUMANN value: 0.0
+  }
+  boundary_info {
+    dim: 2 location: 1 type: BC_TYPE_NEUMANN value: 0.0
+  }
+}
+boundary_conditions {
+  name: "v"
+  boundary_info {
+    dim: 0 location: 0 type: BC_TYPE_DIRICHLET value: 0.0
+  }
+  boundary_info {
+    dim: 0 location: 1 type: BC_TYPE_NEUMANN value: 0.0
+  }
+  boundary_info {
+    dim: 2 location: 0 type: BC_TYPE_NEUMANN value: 0.0
+  }
+  boundary_info {
+    dim: 2 location: 1 type: BC_TYPE_NEUMANN value: 0.0
+  }
+}
+boundary_conditions {
+  name: "w"
+  boundary_info {
+    dim: 0 location: 0 type: BC_TYPE_DIRICHLET value: 0.0
+  }
+  boundary_info {
+    dim: 0 location: 1 type: BC_TYPE_NEUMANN value: 0.0
+  }
+  boundary_info {
+    dim: 2 location: 0 type: BC_TYPE_NEUMANN value: 0.0
+  }
+  boundary_info {
+    dim: 2 location: 1 type: BC_TYPE_DIRICHLET value: 0.0
+  }
+}
+boundary_conditions {
+  name: "p"
+  boundary_info {
+    dim: 0 location: 0 type: BC_TYPE_NEUMANN value: 0.0
+  }
+  boundary_info {
+    dim: 0 location: 1 type: BC_TYPE_NEUMANN value: 0.0
+  }
+  boundary_info {
+    dim: 2 location: 0 type: BC_TYPE_NEUMANN value: 0.0
+  }
+  boundary_info {
+    dim: 2 location: 1 type: BC_TYPE_NEUMANN value: 0.0
+  }
+}
+boundary_conditions {
+  name: "T"
+  boundary_info {
+    dim: 0 location: 0 type: BC_TYPE_DIRICHLET value: 283.0
+  }
+  boundary_info {
+    dim: 0 location: 1 type: BC_TYPE_NEUMANN value: 0.0
+  }
+  boundary_info {
+    dim: 2 location: 0 type: BC_TYPE_NEUMANN value: 0.0
+  }
+  boundary_info {
+    dim: 2 location: 1 type: BC_TYPE_NEUMANN value: 0.0
+  }
+}
+boundary_conditions {
+  name: "Y_O"
+  boundary_info {
+    dim: 0 location: 0 type: BC_TYPE_DIRICHLET value: 0.21
+  }
+  boundary_info {
+    dim: 0 location: 1 type: BC_TYPE_NEUMANN value: 0.0
+  }
+  boundary_info {
+    dim: 2 location: 0 type: BC_TYPE_NEUMANN value: 0.0
+  }
+  boundary_info {
+    dim: 2 location: 1 type: BC_TYPE_NEUMANN value: 0.0
+  }
+}

--- a/swirl_lm/example/shared/wildfire_utils.py
+++ b/swirl_lm/example/shared/wildfire_utils.py
@@ -563,7 +563,8 @@ class WildfireUtils:
 
     if (self.config.combustion is None or
         not self.config.combustion.HasField('wood')):
-      raise ValueError('Wood model is not defined as a combustion model.')
+      # raise ValueError('Wood model is not defined as a combustion model.')
+      logging.warning('Combustion model deactivated')
 
     # The update function for reactive variables and their source terms.
     self.combustion_step_fn = combustion.combustion_step
@@ -632,9 +633,12 @@ class WildfireUtils:
     )
 
     # Parameters for the drag force.
-    self.drag_force_fn = self.vegetation_drag_update_fn(
-        _C_D.value, self.config.combustion.wood.a_v
-    )
+    if not self.config.combustion is None:
+      self.drag_force_fn = self.vegetation_drag_update_fn(
+          _C_D.value, self.config.combustion.wood.a_v
+      )
+    else:
+      logging.warning('No vegetation drag')
 
     # Parameters for the inflow.
     self.u_mean = self.u_init

--- a/swirl_lm/utility/common_ops.py
+++ b/swirl_lm/utility/common_ops.py
@@ -1574,8 +1574,8 @@ def strip_halos(
   # Handles the case of single 3D tensor.
   if isinstance(f, tf.Tensor):
     nz, nx, ny = f.get_shape().as_list()
-    return f[halos[2]:nz - halos[2], halos[0]:nx - halos[0],
-             halos[1]:ny - halos[1]]
+    return f[halos[2]: - halos[2], halos[0]: - halos[0],
+             halos[1]: - halos[1]]
 
   # Handles the case of a list of 2D tensor.
   nx = f[0].get_shape().as_list()[0]
@@ -1668,8 +1668,8 @@ def gather(x: tf.Tensor, indices: tf.Tensor) -> tf.Tensor:
     matching the first dimension of `indices`.  If `indices` is empty, return
     a vector with length 0.
   """
-  if  tf.shape(indices)[0] == 0:
-    return tf.constant([])
+  # if  tf.shape(indices)[0] == 0: # <-- Unsupported!
+  #   return tf.constant([])
 
   i, j, k = [
       tf.cast(tf.one_hot(indices[:, l], depth=tf.shape(x)[l]), dtype=x.dtype)
@@ -1721,8 +1721,8 @@ def scatter(
     with everywhere else being 0. If `indices` is empty, a 3D tensor with all
     zeros will be returned.
   """
-  if tf.shape(indices)[0] == 0:
-    return tf.zeros(shape, dtype=dtype)
+  # if tf.shape(indices)[0] == 0: # <-- Unsupported!
+  #   return tf.zeros(shape, dtype=dtype)
 
   i, j, k = [
       tf.cast(tf.one_hot(indices[:, l], depth=shape[l]), dtype=x.dtype)


### PR DESCRIPTION
Implemented new ghost point method following [Ghias et al., JCP 225(1), 2007](https://linkinghub.elsevier.com/retrieve/pii/S0021999106006048), with image point interpolation based on [R. Franke, Mathematics of Computation 38(157), 1982](https://www.ams.org/mcom/1982-38-157/S0025-5718-1982-0637296-4/). Image points currently have the same distance from IB surface as ghost points. In this commit, only Dirichlet boundary conditions supported! Includes test case for non-reacting flow over 2D hill ("Witch of Agnesi"/"Agnesi hill") based on [Lundquist et al., Month. Meterol. Rev. 140(12), 2012](http://journals.ametsoc.org/doi/10.1175/MWR-D-11-00311.1).


Notes:
- `common_ops.py` scatter/gather is incompatible with lists, therefore commented out dim-check.
- To run Witch of Agnesi test case, be sure to initialize the Coriolis force in `fire.py` as follows: 
   ```_DEFAULT_LAT = 0.5497607357 # rad == 31.5 deg 
   # Coriolis force coeff of 1e-4 rad/s from Lundquist et al., Month. Meterol.
   # Rev. 2010 for validation of IB methods corresponds to a latitude 
   # defined by _REF_LAT 
   _REF_LAT = 0.7555285998 # rad == 43.289 deg 
   my_lat = _REF_LAT 
   logging.warn(f'Using reference latitude of {my_lat} rad ' 
                f'corresonding to {np.rad2deg(my_lat):.3f} deg.') 
   self.coriolis_force_fn = cloud_utils.coriolis_force(my_lat, { 
       'u': self.fire_utils.u_init, 
       'v': self.fire_utils.v_init, 
       'w': 0.0
   }, 2)```