### PR TITLE
[IB method] Revised ghost point method

### DIFF
--- a/swirl_lm/boundary_condition/immersed_boundary_method.proto
+++ b/swirl_lm/boundary_condition/immersed_boundary_method.proto
@@ -124,8 +124,18 @@ message FeedbackForce1DInterp {
   optional float damping_coeff = 3 [default = 1.0];
 }
 
+message GhostPointMethod {
+  // Variables for which the ghost point method is applied.
+  repeated IBVariableInfo variables = 1;
+  // The dimension along which the immersed boundary is cutting through and
+  // interpolated. Should be one of 0, 1, and 2.
+  optional int32 dim = 2 [default = 2];
+  // The value of the damping coefficient.
+  optional float damping_coeff = 3 [default = 10.0];
+}
+
 // Parameters required by the immersed boundary method.
-// Next id: 7
+// Next id: 8
 message ImmersedBoundaryMethod {
   oneof type {
     CartesianGridMethod cartesian_grid = 1;
@@ -134,5 +144,6 @@ message ImmersedBoundaryMethod {
     DirectForcingMethod direct_forcing = 4;
     DirectForcing1DInterp direct_forcing_1d_interp = 6;
     FeedbackForce1DInterp feedback_force_1d_interp = 5;
+    GhostPointMethod ghost_point_method = 7;
   }
 }

--- a/swirl_lm/equations/scalars.py
+++ b/swirl_lm/equations/scalars.py
@@ -261,7 +261,11 @@ class Scalars(object):
         rho_sc_name = 'rho_{}'.format(scalar_name)
         rhs_name = self._ib.ib_rhs_name(rho_sc_name)
         helper_states = {rhs_name: rhs}
-        for helper_var_name in ('ib_interior_mask', 'ib_boundary'):
+        for helper_var_name in (
+            'ib_interior_mask', 'ib_boundary', 'ib_norm_dist', 'ijk_gp',
+            'gp_mask_T', 'ib_interp_weights', 'idx_p', 'idx_q', 'idx_s',
+            'ib_interp_weights_neumann'
+        ):
           if helper_var_name in additional_states:
             helper_states[helper_var_name] = additional_states[
                 helper_var_name

--- a/swirl_lm/equations/velocity.py
+++ b/swirl_lm/equations/velocity.py
@@ -391,7 +391,11 @@ class Velocity(object):
           var_name = _KEYS_MOMENTUM[dim]
           rhs_name = self._ib.ib_rhs_name(var_name)
           helper_states = {rhs_name: rhs}
-          for helper_var_name in ('ib_interior_mask', 'ib_boundary'):
+          for helper_var_name in (
+              'ib_interior_mask', 'ib_boundary', 'ib_norm_dist', 'ijk_gp',
+              'gp_mask_T', 'ib_interp_weights', 'idx_p', 'idx_q', 'idx_s',
+              'ib_interp_weights_neumann'
+          ):
             if helper_var_name in additional_states:
               helper_states[helper_var_name] = additional_states[
                   helper_var_name

--- a/swirl_lm/example/fire/fire.py
+++ b/swirl_lm/example/fire/fire.py
@@ -1327,6 +1327,7 @@ class Fire:
               coordinates,
               self.map_utils.ib_flow_field_mask_fn(coordinates),
               ib_boundary_fn,
+              self.map_utils.elevation_map,
           )
       )
       # Add an IB boundary field for the support of other modules in case it is

--- a/swirl_lm/example/fire/terrain_utils.py
+++ b/swirl_lm/example/fire/terrain_utils.py
@@ -85,6 +85,34 @@ def generate_terrain_map_from_file(
       method='bicubic')[:, :, 0]
 
 
+def generate_custom_terrain_profile(
+    xx: tf.Tensor,
+    yy: tf.Tensor,
+    profile: str,
+) -> tf.Tensor:
+  """Generate a fluid/solid interface function"""
+  if profile == 'sine':
+    res = 0.2 + 0.1 * tf.math.sin(2. * _PI * xx)
+  elif profile == 'ramp':
+    res = 0.2 + xx * tf.math.tan(3. * _PI / 180.)
+  elif profile == 'witch_of_agnesi':
+    h_p = 100.0  # peak height in meters
+    a = 100.0  # half-width in meters
+    offset = 297.5
+    res = h_p / (1.0 + ((xx - offset) / a)**2.0)
+  elif profile == 'witch_of_agnesi_2d':
+    h_p = 350.0
+    a = 800.0
+    b = 800.0
+    offset = 3000.0
+    z0_offset = 0.
+    res = h_p / (
+        1.0 + ((xx - offset) / a)**2.0 + ((yy - offset) / b)**2.0
+    ) + z0_offset
+
+  return res
+
+
 class TerrainUtils(object):
   """A library for terrain processing in wildfire simulations."""
 


### PR DESCRIPTION
IB surfaces may now be provided as point clouds in a given dimension `dim`. Surface normals are approximated through first order differences. Neumann boundary conditions now preserve 2nd-order accuracy, but only valid for isothermal flows. Density update at the ghost point not yet considered (see [Luo et al., Int. J. Heat Mass Transfer, 2016](https://linkinghub.elsevier.com/retrieve/pii/S0017931015009679)).
All required tensors for ghost point method now automatically initialized by calling `generate_initial_states` in `immersed_boundary_method.py`.

- [ ] `generate_custom_terrain_profile` in `terrain_utils.py` needs to be refactored (avoid `profile` string), or even removed
- [ ] Appropriate density treatment for non-isothermal (reacting) flows